### PR TITLE
fix(ml): make the GPU->CPU fallback recoverable and observable

### DIFF
--- a/docs/guide/detection.rst
+++ b/docs/guide/detection.rst
@@ -372,7 +372,16 @@ Per-model settings:
        labels="/path/to/coco.names",
        min_confidence=0.3,
        pattern="(person|car|dog)",
+       allow_cpu_fallback=True,          # degrade to CPU when CUDA errors
+       gpu_retry_seconds=60,             # then retry the GPU after 60s
    )
+
+A ``gpu`` model that hits a CUDA error moves to CPU so the frame is still
+detected, and retries the GPU after ``gpu_retry_seconds`` (doubling the wait
+after each further failure, up to 15 minutes). Set ``gpu_retry_seconds=0`` to
+make the fallback permanent, or ``allow_cpu_fallback=False`` to raise instead
+of degrading. On a long-running server, see :ref:`serve-gpu-fallback` for how
+to detect a model that is currently degraded.
 
 See the API reference for the full list of fields (face-specific,
 ALPR-specific, AWS, lock management, etc.).

--- a/docs/guide/serve.rst
+++ b/docs/guide/serve.rst
@@ -615,6 +615,14 @@ CLI options
    * - ``--processor``
      - ``cpu``
      - ``cpu``, ``gpu``, or ``tpu``
+   * - ``--no-cpu-fallback``
+     - off
+     - Fail a request instead of degrading to CPU when GPU inference errors.
+       See :ref:`serve-gpu-fallback`.
+   * - ``--gpu-retry-seconds``
+     - ``60``
+     - Seconds on CPU after a GPU failure before the GPU is retried, doubling
+       after each further failure. ``0`` makes a fallback permanent.
    * - ``--auth``
      - off
      - Enable JWT authentication
@@ -695,6 +703,58 @@ Notes:
   workers automatically -- authentication works the same as single-worker
   mode.
 - ``--workers`` is ignored on Windows.
+
+
+.. _serve-gpu-fallback:
+
+When the GPU fails
+~~~~~~~~~~~~~~~~~~~
+
+CUDA errors happen: a driver hiccup, another process holding the device, a
+failed unified-memory allocation. When an inference call on a ``gpu`` model
+raises, the server does not fail the request -- it moves that model to CPU,
+re-runs the frame, and answers. Detection keeps working, several times slower.
+
+That fallback is **temporary**. After ``--gpu-retry-seconds`` (60 by default)
+the next request puts the model back on CUDA. If it fails again the wait
+doubles, up to 15 minutes, so a genuinely broken GPU is not re-probed on every
+request while a momentary fault heals itself within a minute. Both events are
+logged at ``ERROR`` / ``INFO`` by the ``pyzm.ml`` logger:
+
+.. code-block:: text
+
+   pyzm.ml ERROR yolo11m: GPU failed: OpenCV(4.12.0) ... CUDA-capable device(s)
+     is/are busy or unavailable. Falling back to CPU; retrying GPU in 60 seconds.
+   pyzm.ml INFO  yolo11m: retrying GPU inference after an earlier CPU fallback
+
+**Detecting a degraded server.** Logs are not a monitor. ``GET /models``
+reports, per model, the ``processor`` in use right now and the
+``requested_processor`` it was configured with; a gateway that has degraded is
+one where they differ. The endpoint needs no authentication, so a container
+healthcheck can use it directly:
+
+.. code-block:: bash
+
+   curl -sf http://localhost:5000/models \
+     | python3 -c 'import json,sys; m=json.load(sys.stdin)["models"]; \
+       sys.exit(any(x["processor"] != x["requested_processor"] for x in m))'
+
+**Refusing to degrade.** Some deployments would rather fail a request than
+answer it slowly and silently -- a caller cannot tell a slow answer from a fast
+one, but it can act on an error. ``--no-cpu-fallback`` makes a GPU failure
+propagate instead: ``/infer`` returns ``{"detections": [], "error": "..."}``
+and the model stays on GPU for the next request.
+
+.. code-block:: bash
+
+   # never answer from CPU; retry the GPU after 30s instead of 60s
+   python -m pyzm.serve --models yolo11m --processor gpu \
+       --no-cpu-fallback --gpu-retry-seconds 30
+
+Both settings also exist per-model as ``allow_cpu_fallback`` and
+``gpu_retry_seconds`` on a ``ModelConfig`` (in a ``detector_config`` block or
+an ``ml_sequence`` entry). The CLI flags apply to every model the server loads
+and are only stamped onto the model configs when you pass them.
 
 
 Client usage
@@ -846,18 +906,27 @@ Health check. Returns:
 ``GET /models``
 ~~~~~~~~~~~~~~~~
 
-Returns the list of available models and their load status. Useful with
-``--models all`` to check which backends have been lazily loaded, and to confirm
-the ``name`` and ``type`` a client must ask for (:ref:`serve-correlation`).
+Returns the list of available models, their load status, and the processor each
+one is running on. Useful with ``--models all`` to check which backends have
+been lazily loaded, to confirm the ``name`` and ``type`` a client must ask for
+(:ref:`serve-correlation`), and to detect a GPU model that has degraded to CPU
+(:ref:`serve-gpu-fallback`).
 
 .. code-block:: json
 
    {
      "models": [
-       {"name": "yolo11s", "type": "object", "framework": "opencv", "loaded": true},
-       {"name": "yolo26s", "type": "object", "framework": "opencv", "loaded": false}
+       {"name": "yolo11s", "type": "object", "framework": "opencv",
+        "loaded": true, "processor": "gpu", "requested_processor": "gpu"},
+       {"name": "yolo26s", "type": "object", "framework": "opencv",
+        "loaded": false, "processor": "cpu", "requested_processor": "cpu"}
      ]
    }
+
+``processor`` is what inference is running on **now**; ``requested_processor``
+is what the model was configured with. They differ only when a GPU model has
+fallen back to CPU. This endpoint is never authenticated, so a container
+healthcheck can compare the two without a token.
 
 ``POST /infer``
 ~~~~~~~~~~~~~~~~

--- a/pyzm/ml/backends/yolo.py
+++ b/pyzm/ml/backends/yolo.py
@@ -23,6 +23,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("pyzm.ml")
 
+# Ceiling for the escalating GPU-retry backoff, in seconds. A genuinely broken
+# GPU is re-probed at most this often; a transient fault still heals in one
+# gpu_retry_seconds. Refs #66
+_GPU_RETRY_BACKOFF_CAP = 900
+
+
+class _GpuState:
+    """GPU fallback state, shared by every shallow copy of a backend.
+
+    ``pyzm.serve`` shallow-copies a loaded backend to give one request its own
+    ``min_confidence``. The copies share the same ``net``, so they must share
+    this too: a fallback on a copy switches the shared net to CPU, and without
+    shared state the original -- the object ``/models`` reports on, and the one
+    that would retry the GPU -- would go on claiming it runs on GPU.
+    """
+
+    __slots__ = ("processor", "retry_at", "delay")
+
+    def __init__(self, processor: str, delay: int) -> None:
+        self.processor = processor
+        # monotonic deadline after which the GPU is worth retrying;
+        # None = not degraded, or degraded with no retry scheduled.
+        self.retry_at: float | None = None
+        self.delay = delay
+
 
 def _cv2_version() -> tuple[int, int, int]:
     """Return ``(major, minor, patch)`` from ``cv2.__version__``."""
@@ -51,7 +76,7 @@ class YoloBase(MLBackend, PortalockerMixin):
         self._config = config
         self.net = None
         self.classes: list[str] | None = None
-        self.processor = config.processor.value
+        self._gpu = _GpuState(config.processor.value, config.gpu_retry_seconds)
         self.model_height = config.model_height or self._DEFAULT_DIM
         self.model_width = config.model_width or self._DEFAULT_DIM
         self._init_lock()
@@ -66,6 +91,20 @@ class YoloBase(MLBackend, PortalockerMixin):
     def is_loaded(self) -> bool:
         return self.net is not None
 
+    @property
+    def processor(self) -> str:
+        """The processor inference is *actually* running on right now."""
+        return self._gpu.processor
+
+    @processor.setter
+    def processor(self, value: str) -> None:
+        self._gpu.processor = value
+
+    @property
+    def requested_processor(self) -> str:
+        """The processor this model was configured with, fallback or not."""
+        return self._config.processor.value
+
     def load(self) -> None:
         logger.info(
             "%s: loading YOLO model (processor=%s, weights=%s)",
@@ -76,11 +115,11 @@ class YoloBase(MLBackend, PortalockerMixin):
         self._load_model()
 
         # Detect GPU→CPU fallback
-        if self.processor != self._config.processor.value:
+        if self.processor != self.requested_processor:
             logger.warning(
                 "%s: requested processor=%s but fell back to %s",
                 self.name,
-                self._config.processor.value,
+                self.requested_processor,
                 self.processor,
             )
         else:
@@ -112,26 +151,31 @@ class YoloBase(MLBackend, PortalockerMixin):
             if self._config.min_confidence < conf_threshold:
                 conf_threshold = self._config.min_confidence
 
+            self._maybe_restore_gpu()
+
             _t0 = _time.perf_counter()
             try:
                 class_ids, confidences, boxes = self._forward_and_parse(
                     blob, Width, Height, conf_threshold
                 )
-            except cv2.error as e:
                 if self.processor == "gpu":
+                    # A healthy run clears the escalating retry backoff, so the
+                    # next transient fault is retried after the base delay.
+                    self._gpu.delay = self._config.gpu_retry_seconds
+            except cv2.error as e:
+                if self.processor != "gpu":
+                    raise
+                if not self._config.allow_cpu_fallback:
                     logger.error(
-                        "%s: GPU inference failed: %s. Falling back to CPU.",
+                        "%s: GPU inference failed and CPU fallback is disabled: %s",
                         self.name,
                         e,
                     )
-                    self.processor = "cpu"
-                    self.net.setPreferableBackend(cv2.dnn.DNN_BACKEND_OPENCV)
-                    self.net.setPreferableTarget(cv2.dnn.DNN_TARGET_CPU)
-                    class_ids, confidences, boxes = self._forward_and_parse(
-                        blob, Width, Height, conf_threshold
-                    )
-                else:
                     raise
+                self._fall_back_to_cpu(e)
+                class_ids, confidences, boxes = self._forward_and_parse(
+                    blob, Width, Height, conf_threshold
+                )
 
             diff_time = f"{(_time.perf_counter() - _t0) * 1000:.2f} ms"
             logger.debug(
@@ -200,6 +244,61 @@ class YoloBase(MLBackend, PortalockerMixin):
         with open(labels_path, "r") as f:
             self.classes = [line.strip() for line in f.readlines()]
 
+    def _fall_back_to_cpu(self, reason: object, *, retry: bool = True) -> None:
+        """Move the net to CPU after a GPU failure and schedule a GPU retry.
+
+        The fallback used to be permanent: a single transient CUDA error pinned
+        a long-lived server to CPU for the rest of the process, several times
+        slower, with nothing but one log line to say so. Scheduling a retry lets
+        a momentary fault heal itself; the wait doubles on each further failure
+        so a genuinely broken GPU is not re-probed on every request.
+
+        *retry* is False for conditions that cannot heal (an OpenCV build with
+        no CUDA support at all). Refs #66
+        """
+        import cv2
+
+        self.processor = "cpu"
+        if self.net is not None:
+            self.net.setPreferableBackend(cv2.dnn.DNN_BACKEND_OPENCV)
+            self.net.setPreferableTarget(cv2.dnn.DNN_TARGET_CPU)
+
+        wait = self._gpu.delay if retry else 0
+        if wait <= 0:
+            self._gpu.retry_at = None
+            logger.error(
+                "%s: GPU failed: %s. Falling back to CPU for the life of this "
+                "process (GPU retry disabled).",
+                self.name,
+                reason,
+            )
+            return
+
+        self._gpu.retry_at = _time.monotonic() + wait
+        self._gpu.delay = min(wait * 2, _GPU_RETRY_BACKOFF_CAP)
+        logger.error(
+            "%s: GPU failed: %s. Falling back to CPU; retrying GPU in %d seconds.",
+            self.name,
+            reason,
+            wait,
+        )
+
+    def _maybe_restore_gpu(self) -> None:
+        """Put the net back on CUDA once the fallback backoff has elapsed."""
+        if self._gpu.retry_at is None or _time.monotonic() < self._gpu.retry_at:
+            return
+
+        import cv2
+
+        self._gpu.retry_at = None
+        logger.info("%s: retrying GPU inference after an earlier CPU fallback", self.name)
+        self.processor = "gpu"
+        try:
+            self.net.setPreferableBackend(cv2.dnn.DNN_BACKEND_CUDA)
+            self.net.setPreferableTarget(cv2.dnn.DNN_TARGET_CUDA)
+        except Exception as e:
+            self._fall_back_to_cpu(e)
+
     def _setup_gpu(self, cv2_ver: tuple[int, int, int]) -> None:
         """Configure CUDA backend if processor is 'gpu' and OpenCV supports it."""
         import cv2
@@ -221,14 +320,7 @@ class YoloBase(MLBackend, PortalockerMixin):
                 self.net.setPreferableBackend(cv2.dnn.DNN_BACKEND_CUDA)
                 self.net.setPreferableTarget(cv2.dnn.DNN_TARGET_CUDA)
             except Exception as e:
-                logger.error(
-                    "%s: failed to set CUDA backend: %s. Falling back to CPU.",
-                    self.name,
-                    e,
-                )
-                self.processor = "cpu"
-                self.net.setPreferableBackend(cv2.dnn.DNN_BACKEND_OPENCV)
-                self.net.setPreferableTarget(cv2.dnn.DNN_TARGET_CPU)
+                self._fall_back_to_cpu(f"CUDA backend setup failed: {e}")
 
     def _create_blob(self, image: "np.ndarray"):
         import cv2

--- a/pyzm/models/config.py
+++ b/pyzm/models/config.py
@@ -557,6 +557,23 @@ class ServerConfig(BaseModel):
     )
     base_path: str = "/var/lib/zmeventnotification/models"
     processor: Processor = Processor.CPU
+    allow_cpu_fallback: bool = Field(
+        default=True,
+        description=(
+            "When False, a model asked to run on the GPU raises instead of "
+            "degrading to CPU after a CUDA failure. A gateway that has quietly "
+            "become a CPU gateway is invisible to its callers; failing the "
+            "request instead is not."
+        ),
+    )
+    gpu_retry_seconds: int | None = Field(
+        default=None,
+        description=(
+            "Seconds a model stays on CPU after a GPU failure before the GPU is "
+            "retried, doubling after each further failure. None leaves each "
+            "model's own value (60s) in place; 0 makes the fallback permanent."
+        ),
+    )
     detector_config: DetectorConfig | None = None
     auth_enabled: bool = False
     auth_username: str = "admin"

--- a/pyzm/models/config.py
+++ b/pyzm/models/config.py
@@ -162,6 +162,15 @@ class ModelConfig(BaseModel):
     aws_access_key_id: str | None = None
     aws_secret_access_key: str | None = None
 
+    # GPU fallback policy (OpenCV DNN backends).
+    # A CUDA failure normally degrades the model to CPU so the request is still
+    # answered. allow_cpu_fallback=False raises instead, for deployments that
+    # would rather fail than answer slowly and silently. gpu_retry_seconds is
+    # how long to stay on CPU before probing the GPU again -- the wait doubles
+    # after each further failure, and 0 makes the fallback permanent.
+    allow_cpu_fallback: bool = True
+    gpu_retry_seconds: int = 60
+
     # Lock management
     disable_locks: bool = False
     max_lock_wait: int = 120
@@ -387,6 +396,7 @@ def _seq_item_to_model_config(
         "aws_region", "aws_access_key_id", "aws_secret_access_key",
         "disable_locks", "max_lock_wait", "max_processes",
         "pre_existing_labels",
+        "allow_cpu_fallback", "gpu_retry_seconds",
     })
     options = {k: v for k, v in seq.items() if k not in _KNOWN_SEQ_KEYS}
 
@@ -426,6 +436,8 @@ def _seq_item_to_model_config(
         aws_region=seq.get("aws_region", "us-east-1"),
         aws_access_key_id=seq.get("aws_access_key_id"),
         aws_secret_access_key=seq.get("aws_secret_access_key"),
+        allow_cpu_fallback=_bool(seq.get("allow_cpu_fallback", True), default=True),
+        gpu_retry_seconds=int(seq.get("gpu_retry_seconds", 60)),
         disable_locks=_bool(seq.get("disable_locks") or global_general.get("disable_locks", "no")),
         max_lock_wait=int(seq.get("max_lock_wait", global_general.get("max_lock_wait", 120))),
         max_processes=int(seq.get("max_processes", global_general.get("max_processes", 1))),

--- a/pyzm/serve/__main__.py
+++ b/pyzm/serve/__main__.py
@@ -27,6 +27,26 @@ def main() -> None:
     )
     ap.add_argument("--base-path", default="/var/lib/zmeventnotification/models")
     ap.add_argument("--processor", default="cpu", choices=["cpu", "gpu", "tpu"])
+    ap.add_argument(
+        "--no-cpu-fallback",
+        dest="allow_cpu_fallback",
+        action="store_false",
+        help=(
+            "Fail a request instead of silently degrading to CPU when GPU "
+            "inference errors. Without this, a GPU model that hits a CUDA "
+            "error keeps answering -- several times slower."
+        ),
+    )
+    ap.add_argument(
+        "--gpu-retry-seconds",
+        type=int,
+        default=None,
+        help=(
+            "Seconds to stay on CPU after a GPU failure before retrying the "
+            "GPU, doubling after each further failure (default 60). "
+            "0 makes a fallback permanent for the life of the process."
+        ),
+    )
     ap.add_argument("--host", default="0.0.0.0")
     ap.add_argument("--port", type=int, default=5000)
     ap.add_argument("--auth", action="store_true", help="Enable JWT authentication")
@@ -71,6 +91,8 @@ def main() -> None:
             models=args.models,
             base_path=args.base_path,
             processor=Processor(args.processor),
+            allow_cpu_fallback=args.allow_cpu_fallback,
+            gpu_retry_seconds=args.gpu_retry_seconds,
             auth_enabled=args.auth,
             auth_username=args.auth_user,
             auth_password=args.auth_password,

--- a/pyzm/serve/app.py
+++ b/pyzm/serve/app.py
@@ -18,7 +18,7 @@ import requests as http_requests
 from fastapi import Depends, FastAPI, File, Form, HTTPException, UploadFile
 
 from pyzm.ml.detector import Detector
-from pyzm.models.config import ServerConfig
+from pyzm.models.config import ModelConfig, ServerConfig
 from pyzm.serve.auth import create_login_route, create_token_dependency
 
 logger = logging.getLogger("pyzm.serve")
@@ -53,6 +53,26 @@ def config_from_env() -> ServerConfig:
 
     raw = os.environ.get(_CONFIG_ENV_VAR)
     return ServerConfig.model_validate(json.loads(raw)) if raw else ServerConfig()
+
+
+def _apply_gpu_policy(
+    models: list["ModelConfig"], config: ServerConfig
+) -> list["ModelConfig"]:
+    """Stamp the server-wide GPU-fallback policy onto every model config.
+
+    ``--no-cpu-fallback`` / ``--gpu-retry-seconds`` are operator decisions about
+    the whole gateway, but the behaviour lives on each backend's ModelConfig.
+    Only options the operator actually set are applied, so a per-model value
+    from a ``detector_config`` is never silently overwritten. Refs #66
+    """
+    update: dict[str, Any] = {}
+    if not config.allow_cpu_fallback:
+        update["allow_cpu_fallback"] = False
+    if config.gpu_retry_seconds is not None:
+        update["gpu_retry_seconds"] = config.gpu_retry_seconds
+    if not update:
+        return models
+    return [mc.model_copy(update=update) for mc in models]
 
 
 def get_app() -> FastAPI:
@@ -94,6 +114,7 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                 base_path=config.base_path,
                 processor=config.processor,
             )
+        detector._config.models = _apply_gpu_policy(detector._config.models, config)
         detector._ensure_pipeline(lazy=lazy)
         app.state.detector = detector
         mode = "lazy" if lazy else "eager"
@@ -136,6 +157,12 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                 "type": mc.type.value,
                 "framework": mc.framework.value,
                 "loaded": backend.is_loaded,
+                # What inference is running on *now* vs what was asked for. A
+                # GPU model that hit a CUDA error reports processor="cpu" here,
+                # which is the only thing that makes a degraded gateway visible
+                # to a healthcheck. Refs #66
+                "processor": getattr(backend, "processor", mc.processor.value),
+                "requested_processor": mc.processor.value,
             })
         return {"models": result}
 

--- a/tests/test_ml/test_gpu_fallback.py
+++ b/tests/test_ml/test_gpu_fallback.py
@@ -1,0 +1,212 @@
+"""GPU -> CPU fallback behaviour of the YOLO backends.
+
+A transient CUDA error used to pin a backend to CPU for the life of the
+object, which on a long-running ``pyzm.serve`` process turned a momentary
+glitch into an indefinite slowdown that nothing reported. These tests cover
+the recoverable fallback (retry after a backoff), the strict mode that refuses
+to degrade at all, and the state sharing the server's per-request backend copy
+depends on.
+
+Refs #66
+"""
+
+from __future__ import annotations
+
+import copy
+import time
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+cv2 = pytest.importorskip("cv2")
+
+from pyzm.ml.backends.yolo import YoloBase  # noqa: E402
+from pyzm.models.config import ModelConfig, Processor  # noqa: E402
+
+
+IMAGE = np.zeros((100, 100, 3), dtype=np.uint8)
+
+# One person detection, in the (class_ids, confidences, boxes) shape
+# _forward_and_parse returns.
+DETECTION = ([0], [0.9], [[10.0, 10.0, 20.0, 20.0]])
+
+
+class _ScriptedYolo(YoloBase):
+    """A YoloBase whose forward pass is scripted by the test.
+
+    Each entry of *results* is consumed by one ``_forward_and_parse`` call and
+    is either an exception to raise or a ``(class_ids, confidences, boxes)``
+    tuple to return.
+    """
+
+    def __init__(self, config: ModelConfig, results: list) -> None:
+        super().__init__(config)
+        self._results = list(results)
+        self.net = MagicMock()
+        self.classes = ["person"]
+        # processor in effect at each forward call, in order
+        self.forward_processors: list[str] = []
+
+    def _load_model(self) -> None:  # pragma: no cover - net is pre-set
+        raise AssertionError("load() must not run: net is already set")
+
+    def _forward_and_parse(self, blob, width, height, conf_threshold):
+        self.forward_processors.append(self.processor)
+        outcome = self._results.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _make(results, *, processor=Processor.GPU, **cfg) -> _ScriptedYolo:
+    config = ModelConfig(
+        name="yolo11m",
+        processor=processor,
+        disable_locks=True,
+        **cfg,
+    )
+    return _ScriptedYolo(config, results)
+
+
+class TestTransientGpuFailure:
+    """A GPU error degrades to CPU, answers the request, and schedules a retry."""
+
+    def test_falls_back_to_cpu_and_still_answers(self):
+        b = _make([cv2.error("CUDA-capable device(s) is/are busy"), DETECTION])
+
+        detections = b.detect(IMAGE)
+
+        assert [d.label for d in detections] == ["person"]
+        assert b.processor == "cpu"
+        assert b.forward_processors == ["gpu", "cpu"]
+        assert b.net.setPreferableTarget.call_args[0][0] == cv2.dnn.DNN_TARGET_CPU
+
+    def test_requested_processor_survives_the_fallback(self):
+        b = _make([cv2.error("boom"), DETECTION])
+
+        b.detect(IMAGE)
+
+        assert b.processor == "cpu"
+        assert b.requested_processor == "gpu"
+
+    def test_fallback_schedules_a_gpu_retry(self):
+        b = _make([cv2.error("boom"), DETECTION])
+
+        b.detect(IMAGE)
+
+        assert b._gpu.retry_at is not None
+        assert b._gpu.retry_at - time.monotonic() == pytest.approx(60, abs=5)
+
+    def test_gpu_is_not_retried_before_the_backoff_elapses(self):
+        b = _make([cv2.error("boom"), DETECTION, DETECTION])
+
+        b.detect(IMAGE)
+        b.detect(IMAGE)
+
+        assert b.processor == "cpu"
+        assert b.forward_processors == ["gpu", "cpu", "cpu"]
+
+    def test_gpu_is_retried_once_the_backoff_elapses(self):
+        b = _make([cv2.error("boom"), DETECTION, DETECTION])
+        b.detect(IMAGE)
+        b._gpu.retry_at = time.monotonic() - 1  # backoff has elapsed
+
+        b.detect(IMAGE)
+
+        assert b.processor == "gpu"
+        assert b.forward_processors == ["gpu", "cpu", "gpu"]
+        assert b.net.setPreferableBackend.call_args[0][0] == cv2.dnn.DNN_BACKEND_CUDA
+        assert b.net.setPreferableTarget.call_args[0][0] == cv2.dnn.DNN_TARGET_CUDA
+
+    def test_repeated_failures_escalate_the_backoff(self):
+        b = _make([cv2.error("boom"), DETECTION, cv2.error("boom"), DETECTION])
+        b.detect(IMAGE)
+        first_wait = b._gpu.retry_at - time.monotonic()
+        b._gpu.retry_at = time.monotonic() - 1
+
+        b.detect(IMAGE)  # retries GPU, fails again
+
+        second_wait = b._gpu.retry_at - time.monotonic()
+        assert second_wait == pytest.approx(first_wait * 2, abs=5)
+
+    def test_a_healthy_gpu_run_resets_the_backoff(self):
+        b = _make([cv2.error("boom"), DETECTION, DETECTION, cv2.error("boom"), DETECTION])
+        b.detect(IMAGE)
+        b._gpu.retry_at = time.monotonic() - 1
+        b.detect(IMAGE)  # GPU healthy again -> backoff back to the base delay
+
+        b.detect(IMAGE)  # fails once more
+
+        assert b._gpu.retry_at - time.monotonic() == pytest.approx(60, abs=5)
+
+    def test_retry_seconds_zero_makes_the_fallback_permanent(self):
+        b = _make([cv2.error("boom"), DETECTION, DETECTION], gpu_retry_seconds=0)
+
+        b.detect(IMAGE)
+        b.detect(IMAGE)
+
+        assert b._gpu.retry_at is None
+        assert b.processor == "cpu"
+        assert b.forward_processors == ["gpu", "cpu", "cpu"]
+
+
+class TestStrictMode:
+    """``allow_cpu_fallback=False``: fail the request rather than answer slowly."""
+
+    def test_gpu_error_is_raised_instead_of_degrading(self):
+        b = _make([cv2.error("boom")], allow_cpu_fallback=False)
+
+        with pytest.raises(cv2.error):
+            b.detect(IMAGE)
+
+        assert b.processor == "gpu"
+        assert b.forward_processors == ["gpu"]
+
+    def test_a_cpu_error_is_never_swallowed(self):
+        b = _make([cv2.error("bad blob")], processor=Processor.CPU)
+
+        with pytest.raises(cv2.error):
+            b.detect(IMAGE)
+
+        assert b.forward_processors == ["cpu"]
+
+
+class TestSharedFallbackState:
+    """pyzm.serve shallow-copies a backend to give one request its own threshold.
+
+    The copy shares the loaded ``net``, so it must share the fallback state too:
+    otherwise a fallback on the copy switches the shared net to CPU while the
+    original -- the one ``/models`` reports on and the one that would retry the
+    GPU -- still claims to be running on GPU.
+    """
+
+    def test_a_shallow_copy_shares_the_fallback_state(self):
+        b = _make([cv2.error("boom"), DETECTION])
+        request_copy = copy.copy(b)
+
+        request_copy.detect(IMAGE)
+
+        assert b.processor == "cpu"
+        assert b._gpu.retry_at is not None
+
+
+class TestSetupGpuFallback:
+    """Load-time GPU setup degrades the same way, but only when it may recover."""
+
+    def test_a_failed_cuda_setup_schedules_a_retry(self):
+        b = _make([])
+        b.net.setPreferableBackend.side_effect = [cv2.error("no CUDA context"), None]
+
+        b._setup_gpu((4, 12, 0))
+
+        assert b.processor == "cpu"
+        assert b._gpu.retry_at is not None
+
+    def test_opencv_without_cuda_support_never_retries(self):
+        b = _make([])
+
+        b._setup_gpu((4, 1, 0))  # < 4.2: this build cannot ever use CUDA
+
+        assert b.processor == "cpu"
+        assert b._gpu.retry_at is None

--- a/tests/test_ml_e2e/test_remote_serve.py
+++ b/tests/test_ml_e2e/test_remote_serve.py
@@ -60,6 +60,10 @@ class TestRemoteDetection:
             models = data["models"]
             assert len(models) > 0
             assert models[0]["loaded"] is True
+            # The processor actually in use, so a degraded gateway is visible
+            # (start_serve runs the server with --processor cpu). Refs #66
+            assert models[0]["processor"] == "cpu"
+            assert models[0]["requested_processor"] == "cpu"
         finally:
             stop_serve(proc)
 

--- a/tests/test_models/test_config.py
+++ b/tests/test_models/test_config.py
@@ -298,6 +298,37 @@ class TestDetectorConfig:
         assert len(dc.models) == 1
         assert dc.models[0].enabled is False
 
+    def test_from_dict_gpu_fallback_policy(self):
+        """A sequence entry can set the GPU fallback policy. Refs #66"""
+        ml_options = {
+            "general": {"model_sequence": "object"},
+            "object": {
+                "general": {},
+                "sequence": [
+                    {
+                        "name": "strict-gpu",
+                        "object_processor": "gpu",
+                        "allow_cpu_fallback": "no",
+                        "gpu_retry_seconds": "30",
+                    },
+                ],
+            },
+        }
+        dc = DetectorConfig.from_dict(ml_options)
+        assert dc.models[0].allow_cpu_fallback is False
+        assert dc.models[0].gpu_retry_seconds == 30
+        # recognised keys must not leak into the catch-all options dict
+        assert dc.models[0].options == {}
+
+    def test_from_dict_gpu_fallback_policy_defaults(self):
+        ml_options = {
+            "general": {"model_sequence": "object"},
+            "object": {"general": {}, "sequence": [{"name": "t"}]},
+        }
+        dc = DetectorConfig.from_dict(ml_options)
+        assert dc.models[0].allow_cpu_fallback is True
+        assert dc.models[0].gpu_retry_seconds == 60
+
     def test_from_dict_unknown_model_type_skipped(self):
         ml_options = {
             "general": {"model_sequence": "object,unknown_type"},

--- a/tests/test_serve/test_models_all.py
+++ b/tests/test_serve/test_models_all.py
@@ -32,8 +32,12 @@ class TestServerConfigModelsAll:
 # /models endpoint
 # ---------------------------------------------------------------------------
 
-def _mock_detector(lazy: bool = False):
-    """Return a mock Detector with a mock pipeline."""
+def _mock_detector(lazy: bool = False, processor: str = "cpu", requested: str = "cpu"):
+    """Return a mock Detector with a mock pipeline.
+
+    *processor* is what the backend is running on now and *requested* what it
+    was configured with -- they differ once a GPU model has fallen back to CPU.
+    """
     det = MagicMock()
     det._pipeline = MagicMock()
     det._config = MagicMock()
@@ -53,9 +57,11 @@ def _mock_detector(lazy: bool = False):
     mc_mock.name = "yolov4"
     mc_mock.type.value = "object"
     mc_mock.framework.value = "opencv"
+    mc_mock.processor.value = requested
 
     backend_mock = MagicMock()
     backend_mock.is_loaded = not lazy
+    backend_mock.processor = processor
 
     det._pipeline._backends = [(mc_mock, backend_mock)]
     return det
@@ -111,6 +117,96 @@ class TestModelsEndpoint:
         data = resp.json()
         assert len(data["models"]) == 1
         assert data["models"][0]["loaded"] is False
+
+    def test_models_reports_the_processor_in_use(self, client_eager):
+        """The live processor is the only signal a gateway is degraded. Refs #66"""
+        entry = client_eager.get("/models").json()["models"][0]
+        assert entry["processor"] == "cpu"
+        assert entry["requested_processor"] == "cpu"
+
+    def test_models_reports_a_gpu_model_that_fell_back_to_cpu(self):
+        """A GPU model running on CPU must say so, not report what it asked for."""
+        config = ServerConfig(models=["yolov4"])
+        with patch("pyzm.serve.app.Detector") as MockDetector:
+            mock_det = _mock_detector(processor="cpu", requested="gpu")
+            MockDetector.return_value = mock_det
+            mock_det._ensure_pipeline = MagicMock(return_value=mock_det._pipeline)
+
+            from pyzm.serve.app import create_app
+            from fastapi.testclient import TestClient
+
+            with TestClient(create_app(config)) as tc:
+                entry = tc.get("/models").json()["models"][0]
+
+        assert entry["processor"] == "cpu"
+        assert entry["requested_processor"] == "gpu"
+
+
+class TestGpuPolicy:
+    """The server's GPU-fallback policy reaches the model configs. Refs #66"""
+
+    def _models(self):
+        from pyzm.models.config import ModelConfig
+
+        return [ModelConfig(name="a"), ModelConfig(name="b")]
+
+    def test_strict_mode_and_retry_interval_are_stamped_on_every_model(self):
+        from pyzm.serve.app import _apply_gpu_policy
+
+        config = ServerConfig(allow_cpu_fallback=False, gpu_retry_seconds=30)
+        models = _apply_gpu_policy(self._models(), config)
+
+        assert [m.allow_cpu_fallback for m in models] == [False, False]
+        assert [m.gpu_retry_seconds for m in models] == [30, 30]
+
+    def test_defaults_leave_the_model_configs_alone(self):
+        """Without a server-level override, per-model values must survive."""
+        from pyzm.serve.app import _apply_gpu_policy
+
+        models = self._models()
+        assert _apply_gpu_policy(models, ServerConfig()) is models
+
+    def _config_from_cli(self, argv):
+        """Run the serve CLI with *argv* and return the ServerConfig it built."""
+        import sys
+
+        from pyzm.serve import __main__ as serve_main
+
+        with patch.object(sys, "argv", ["pyzm.serve", *argv]), \
+                patch("uvicorn.run"), \
+                patch("pyzm.serve.app.create_app") as create_app:
+            serve_main.main()
+        return create_app.call_args[0][0]
+
+    def test_cli_defaults_keep_the_fallback_on(self):
+        config = self._config_from_cli([])
+
+        assert config.allow_cpu_fallback is True
+        assert config.gpu_retry_seconds is None
+
+    def test_cli_flags_set_the_policy(self):
+        config = self._config_from_cli(
+            ["--processor", "gpu", "--no-cpu-fallback", "--gpu-retry-seconds", "30"]
+        )
+
+        assert config.allow_cpu_fallback is False
+        assert config.gpu_retry_seconds == 30
+
+    def test_the_lifespan_applies_the_policy(self):
+        from pyzm.models.config import ModelConfig
+
+        config = ServerConfig(models=["yolov4"], allow_cpu_fallback=False)
+        with patch("pyzm.serve.app.Detector") as MockDetector:
+            mock_det = _mock_detector()
+            mock_det._config.models = [ModelConfig(name="yolov4")]
+            MockDetector.return_value = mock_det
+            mock_det._ensure_pipeline = MagicMock(return_value=mock_det._pipeline)
+
+            from pyzm.serve.app import create_app
+            from fastapi.testclient import TestClient
+
+            with TestClient(create_app(config)):
+                assert mock_det._config.models[0].allow_cpu_fallback is False
 
 
 class TestModelsAllLifespan:


### PR DESCRIPTION
Fixes items 1, 2 and 4 of #66. Item 3 (a warm-up inference at start-up) is
deliberately not implemented — that stays with downstream consumers.

## 1. The CPU fallback is recoverable

`YoloBase.detect()` still degrades to CPU and re-runs the frame when GPU
inference raises `cv2.error`, but the degradation is no longer for the life of
the object. The fallback schedules a retry: after `gpu_retry_seconds` (60 by
default) the next `detect()` puts the net back on CUDA, so a transient
`cudaErrorDevicesUnavailable` heals itself. Each further failure doubles the
wait, capped at 15 minutes, so a genuinely broken GPU is not re-probed on every
request; a healthy GPU run resets the backoff. `gpu_retry_seconds=0` keeps the
old permanent behaviour. `_setup_gpu()` uses the same path, except "OpenCV <
4.2, no CUDA support", which cannot heal and is never retried.

The fallback state lives in a shared `_GpuState` object rather than on the
backend instance. `pyzm/serve/app.py` shallow-copies a loaded backend when a
request carries its own `min_confidence`; the copies share the same `net`, so
without shared state a fallback on a copy would switch the real net to CPU
while the original — the object `/models` reports on, and the one that would
retry the GPU — kept claiming GPU.

## 2. `/models` reports the processor in use

Each entry gains `processor` (what inference is running on right now) and
`requested_processor` (what the model was configured with). They differ only
when a model has fallen back. Both keys are additive, and `/models` is
unauthenticated, so a container healthcheck can compare them without a token:

```bash
curl -sf http://localhost:5000/models \
  | python3 -c 'import json,sys; m=json.load(sys.stdin)["models"]; \
    sys.exit(any(x["processor"] != x["requested_processor"] for x in m))'
```

## 4. A strict mode that refuses to degrade

`allow_cpu_fallback=False` makes a GPU failure propagate instead of degrading:
`/infer` answers `{"detections": [], "error": "..."}` and the model stays on
GPU for the next request. Exposed as `--no-cpu-fallback`, alongside
`--gpu-retry-seconds`. Both are stamped onto the loaded model configs only when
passed, so a per-model value from a `detector_config` is never silently
overwritten. Both also exist per-model on `ModelConfig` and are readable from
an `ml_sequence` entry.

## Testing

`tests/test_ml/test_gpu_fallback.py` (new, 13 tests) covers the fallback, the
retry and its backoff, the backoff reset, the permanent mode, strict mode, the
shared state across a shallow copy, and both `_setup_gpu()` paths. Server-side
tests cover the two new `/models` keys, the policy helper, the lifespan
application and the CLI flags; `test_remote_serve.py` asserts the new keys
against a real server.

Every new test was confirmed to fail against the unmodified code first.

Tier-1 gate: **1115 passed, 81 skipped**. Note that it was run in a purpose-built
virtualenv — the system `python3` on the machine this was written on is missing
`portalocker`, `cv2` and `fastapi`, so `make gate` there fails at collection
regardless of this change. `make release-gate` has not been run (needs models
and a live ZM).

## Docs

New "When the GPU fails" section in `docs/guide/serve.rst` (with the
healthcheck above), the updated `/models` response, the two CLI flags, and the
`ModelConfig` fields in `docs/guide/detection.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4NMrnE6Z2SBXt6B2Tm8eS
