### PR TITLE
feat(ml): make zone resolution selectable with zone_match_strategy

### DIFF
--- a/docs/guide/detection.rst
+++ b/docs/guide/detection.rst
@@ -349,6 +349,7 @@ Top-level detection settings:
        frame_strategy="most_models",     # first | most | most_unique | most_models
        pattern=".*",                     # global label regex filter
        max_detection_size="50%",         # max bbox size (% of image or "Npx")
+       zone_match_strategy="any_matching",  # how overlapping zones are resolved
        match_past_detections=False,      # compare with previous run
        past_det_max_diff_area="5%",      # area tolerance for past matching
        type_overrides={...},             # per-type overrides (see below)
@@ -718,6 +719,10 @@ specific zones:
             ignore_pattern="(car|truck)"),  # suppress parked vehicles
    ]
 
+Whether a suppression sticks when the box also overlaps another zone
+depends on ``zone_match_strategy`` — see
+:ref:`resolving-overlapping-zones` below.
+
 .. note::
 
    When no zones are passed (or the list is empty), zone filtering is
@@ -725,6 +730,61 @@ specific zones:
 
 When using ZoneMinder events, use ``zm.monitor(monitor_id).get_zones()`` to
 fetch zones configured in the ZM web UI.
+
+
+.. _resolving-overlapping-zones:
+
+Resolving overlapping zones
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A zone matches when the bounding box *intersects* the polygon, not when it
+is contained by it, so one detection can land in several zones at once — a
+car in the street whose box dips a few pixels into the driveway is in both.
+``zone_match_strategy`` decides which of those zones gets to rule on the
+detection:
+
+``any_matching`` (default)
+   The detection is kept as soon as *any* intersecting zone's ``pattern``
+   matches it.  A zone that rejects it does not stop a later zone from
+   keeping it, so an exclusion zone bordering a permissive one can be
+   defeated by a few pixels of overlap.
+
+``first_intersecting``
+   The first intersecting zone decides, whether it keeps or rejects.  This
+   is the pyzm 0.3.x / ES 6 behaviour, and is what an ES 6 config was
+   written against.  It depends on the order zones are listed in.
+
+``largest_overlap``
+   The zone covering the largest share of the bounding box decides; ties go
+   to the earlier zone.  Order-independent, and it resolves the sliver case
+   the way an operator expects.
+
+Under ``first_intersecting`` and ``largest_overlap`` a rejection is final —
+by ``ignore_pattern`` or by a ``pattern`` mismatch — which is what makes
+"never alert on this label here" expressible.  Under ``any_matching`` it is
+not: another zone can still rescue the detection.
+
+.. code-block:: python
+
+   config = DetectorConfig(
+       models=[...],
+       zone_match_strategy="largest_overlap",
+   )
+
+In ``objectconfig.yml`` it is a top-level ``general`` key:
+
+.. code-block:: yaml
+
+   ml_sequence:
+     general:
+       model_sequence: "object"
+       zone_match_strategy: "largest_overlap"
+
+.. note::
+
+   The default stays ``any_matching`` so upgrading pyzm does not silently
+   change which detections survive.  Set it explicitly if you rely on
+   exclusion zones.
 
 
 .. _per-type-overrides:
@@ -750,6 +810,8 @@ override it takes precedence; otherwise the global value is used.
 - ``frame_strategy`` — operates above model types (picks best frame
   across all types)
 - ``image_path`` — just a directory path, no per-type meaning
+- ``zone_match_strategy`` — zone filtering runs once, after all model types
+  have been sequenced
 
 In Python:
 

--- a/docs/guide/serve.rst
+++ b/docs/guide/serve.rst
@@ -490,7 +490,7 @@ returned detections, so it is identical local and remote:
 
 - ``min_confidence`` (sent on the ``/infer`` call and applied in place of the
   value this server loaded the model with)
-- ``pattern``, zones, ``max_detection_size``
+- ``pattern``, zones (including ``zone_match_strategy``), ``max_detection_size``
 - ``model_sequence``, ``same_model_sequence_strategy``, ``frame_strategy``
 - past-detection filtering and ``pre_existing_labels`` gating
 

--- a/pyzm/ml/detector.py
+++ b/pyzm/ml/detector.py
@@ -356,7 +356,10 @@ class Detector:
 
         detections = filter_by_pattern(detections, self._config.pattern)
         detections = filter_by_size(detections, self._config.max_detection_size, (h, w))
-        detections, error_boxes = filter_by_zone(detections, zone_dicts, (h, w))
+        detections, error_boxes = filter_by_zone(
+            detections, zone_dicts, (h, w),
+            strategy=self._config.zone_match_strategy,
+        )
         detections = filter_past_per_type(detections, self._config)
 
         return detections, error_boxes

--- a/pyzm/ml/filters.py
+++ b/pyzm/ml/filters.py
@@ -12,6 +12,7 @@ import os
 import re
 from typing import TYPE_CHECKING
 
+from pyzm.models.config import ZoneMatchStrategy
 from pyzm.models.detection import BBox, Detection
 
 if TYPE_CHECKING:
@@ -24,10 +25,134 @@ logger = logging.getLogger("pyzm.ml")
 # Zone filtering
 # ---------------------------------------------------------------------------
 
+def _zone_points(zone: dict) -> list:
+    """Polygon points of *zone*, accepting either the ``points`` or ``value`` key."""
+    return zone.get("points") or zone.get("value", [])
+
+
+def _zone_verdict(det: Detection, zone: dict) -> bool:
+    """Apply *zone*'s patterns to *det*.  ``True`` keeps the detection.
+
+    Used by the strategies where a single zone decides the outcome:
+    ``ignore_pattern`` suppresses, then ``pattern`` (default ``.*``) keeps.
+    """
+    zone_name = zone.get("name", "unnamed")
+    zone_ignore = zone.get("ignore_pattern")
+    if zone_ignore and re.match(zone_ignore, det.label):
+        logger.debug(
+            "filter_by_zone: %s matches ignore_pattern %s of deciding zone %s, suppressing",
+            det.label, zone_ignore, zone_name,
+        )
+        return False
+
+    pattern = zone.get("pattern") or ".*"
+    if re.match(pattern, det.label):
+        logger.debug(
+            "filter_by_zone: %s matches pattern %s of deciding zone %s",
+            det.label, pattern, zone_name,
+        )
+        return True
+
+    logger.debug(
+        "filter_by_zone: %s does NOT match pattern %s of deciding zone %s, rejecting",
+        det.label, pattern, zone_name,
+    )
+    return False
+
+
+def _keep_any_matching(det: Detection, bbox_poly, zones: list[dict], Polygon) -> bool:
+    """Keep as soon as any intersecting zone's pattern matches."""
+    for zone in zones:
+        zone_name = zone.get("name", "unnamed")
+        zone_poly = Polygon(_zone_points(zone))
+        if not bbox_poly.intersects(zone_poly):
+            logger.debug(
+                "filter_by_zone: %s does NOT intersect zone %s",
+                det.label, zone_name,
+            )
+            continue
+
+        # Check ignore_pattern first -- suppress matching labels in this zone
+        zone_ignore = zone.get("ignore_pattern")
+        if zone_ignore and re.match(zone_ignore, det.label):
+            logger.debug(
+                "filter_by_zone: %s intersects zone %s and matches ignore_pattern %s, suppressing",
+                det.label, zone_name, zone_ignore,
+            )
+            continue  # try other zones
+
+        # Zone intersects -- now check the pattern
+        pattern = zone.get("pattern") or ".*"
+        if re.match(pattern, det.label):
+            logger.debug(
+                "filter_by_zone: %s intersects zone %s and matches pattern %s",
+                det.label, zone_name, pattern,
+            )
+            return True  # matched on first zone is enough
+
+        logger.debug(
+            "filter_by_zone: %s intersects zone %s but does NOT match pattern %s",
+            det.label, zone_name, pattern,
+        )
+    return False
+
+
+def _keep_first_intersecting(det: Detection, bbox_poly, zones: list[dict], Polygon) -> bool:
+    """The first zone the box intersects decides, whether or not it matches."""
+    for zone in zones:
+        zone_poly = Polygon(_zone_points(zone))
+        if not bbox_poly.intersects(zone_poly):
+            logger.debug(
+                "filter_by_zone: %s does NOT intersect zone %s",
+                det.label, zone.get("name", "unnamed"),
+            )
+            continue
+        return _zone_verdict(det, zone)
+    return False
+
+
+def _keep_largest_overlap(det: Detection, bbox_poly, zones: list[dict], Polygon) -> bool:
+    """The zone covering most of the bounding box decides.  Ties go to the
+    earlier zone."""
+    best_zone: dict | None = None
+    best_area = -1.0
+
+    for zone in zones:
+        zone_poly = Polygon(_zone_points(zone))
+        if not bbox_poly.intersects(zone_poly):
+            logger.debug(
+                "filter_by_zone: %s does NOT intersect zone %s",
+                det.label, zone.get("name", "unnamed"),
+            )
+            continue
+        area = bbox_poly.intersection(zone_poly).area
+        if area > best_area:
+            best_zone, best_area = zone, area
+
+    if best_zone is None:
+        return False
+
+    box_area = bbox_poly.area
+    logger.debug(
+        "filter_by_zone: zone %s covers most of %s (%.1f%% of the box), it decides",
+        best_zone.get("name", "unnamed"), det.label,
+        (best_area / box_area * 100) if box_area else 0.0,
+    )
+    return _zone_verdict(det, best_zone)
+
+
+_ZONE_STRATEGIES = {
+    ZoneMatchStrategy.ANY_MATCHING: _keep_any_matching,
+    ZoneMatchStrategy.FIRST_INTERSECTING: _keep_first_intersecting,
+    ZoneMatchStrategy.LARGEST_OVERLAP: _keep_largest_overlap,
+}
+
+
 def filter_by_zone(
     detections: list[Detection],
     zones: list[dict],
     image_shape: tuple[int, int],
+    strategy: ZoneMatchStrategy | str = ZoneMatchStrategy.ANY_MATCHING,
 ) -> tuple[list[Detection], list[BBox]]:
     """Keep only detections whose bounding box intersects at least one zone.
 
@@ -37,18 +162,35 @@ def filter_by_zone(
         Raw detections from a backend.
     zones:
         Each zone is a dict-like with ``name`` (str), ``points``
-        (list of (x, y) tuples), and optionally ``pattern`` (str | None).
-        These can be :class:`pyzm.models.zm.Zone` objects turned into dicts
-        via :meth:`as_dict`, or simple dicts.
+        (list of (x, y) tuples), and optionally ``pattern`` (str | None) and
+        ``ignore_pattern`` (str | None).  These can be
+        :class:`pyzm.models.zm.Zone` objects turned into dicts via
+        :meth:`as_dict`, or simple dicts.
     image_shape:
-        ``(height, width)`` of the analysed image.  If *zones* is empty a
-        full-image zone is synthesised.
+        ``(height, width)`` of the analysed image.
+    strategy:
+        How to resolve a box that intersects several zones
+        (:class:`~pyzm.models.config.ZoneMatchStrategy`):
+
+        ``any_matching`` (default)
+            Keep as soon as any intersecting zone's ``pattern`` matches.  A
+            zone that rejects the detection does not stop a later zone from
+            keeping it.
+        ``first_intersecting``
+            The first intersecting zone decides, keep or reject.  This is the
+            pyzm 0.3.x / ES 6 behaviour.  Order-dependent.
+        ``largest_overlap``
+            The zone covering the largest share of the bounding box decides.
+            Order-independent; ties go to the earlier zone.
+
+        Under the latter two, a rejection -- by ``ignore_pattern`` or by a
+        ``pattern`` mismatch -- is final, so an exclusion zone cannot be
+        overridden by a zone the box merely clips.
 
     Returns
     -------
     kept:
-        Detections that intersect at least one zone and whose label matches
-        the zone's pattern (or the default ``.*``).
+        Detections kept by the deciding zone(s).
     error_boxes:
         Bounding boxes of detections that were filtered out.
     """
@@ -58,55 +200,16 @@ def filter_by_zone(
 
     from shapely.geometry import Polygon  # optional dependency
 
-    h, w = image_shape
+    keep_fn = _ZONE_STRATEGIES[ZoneMatchStrategy(strategy)]
 
     kept: list[Detection] = []
     error_boxes: list[BBox] = []
 
     for det in detections:
         bbox_poly = Polygon(det.bbox.as_polygon_coords())
-        matched = False
-
-        for zone in zones:
-            # Normalise: accept Zone objects or dicts with 'value'/'points' key
-            zone_points = zone.get("points") or zone.get("value", [])
-            zone_pattern = zone.get("pattern")
-            zone_ignore = zone.get("ignore_pattern")
-            zone_name = zone.get("name", "unnamed")
-
-            zone_poly = Polygon(zone_points)
-            if not bbox_poly.intersects(zone_poly):
-                logger.debug(
-                    "filter_by_zone: %s does NOT intersect zone %s",
-                    det.label, zone_name,
-                )
-                continue
-
-            # Check ignore_pattern first -- suppress matching labels in this zone
-            if zone_ignore and re.match(zone_ignore, det.label):
-                logger.debug(
-                    "filter_by_zone: %s intersects zone %s and matches ignore_pattern %s, suppressing",
-                    det.label, zone_name, zone_ignore,
-                )
-                continue  # try other zones
-
-            # Zone intersects -- now check the pattern
-            pattern = zone_pattern or ".*"
-            if re.match(pattern, det.label):
-                logger.debug(
-                    "filter_by_zone: %s intersects zone %s and matches pattern %s",
-                    det.label, zone_name, pattern,
-                )
-                kept.append(det)
-                matched = True
-                break  # matched on first zone is enough
-            else:
-                logger.debug(
-                    "filter_by_zone: %s intersects zone %s but does NOT match pattern %s",
-                    det.label, zone_name, pattern,
-                )
-
-        if not matched:
+        if keep_fn(det, bbox_poly, zones, Polygon):
+            kept.append(det)
+        else:
             error_boxes.append(det.bbox)
 
     return kept, error_boxes

--- a/pyzm/ml/pipeline.py
+++ b/pyzm/ml/pipeline.py
@@ -286,7 +286,10 @@ class ModelPipeline:
         all_detections = filter_by_size(all_detections, self._config.max_detection_size, (h, w))
 
         # Apply zone filtering (returns kept and error_boxes)
-        all_detections, all_error_boxes = filter_by_zone(all_detections, zone_dicts, (h, w))
+        all_detections, all_error_boxes = filter_by_zone(
+            all_detections, zone_dicts, (h, w),
+            strategy=self._config.zone_match_strategy,
+        )
 
         # Apply past-detection deduplication (per-type with global fallback)
         all_detections = self._filter_past_per_type(all_detections)

--- a/pyzm/models/config.py
+++ b/pyzm/models/config.py
@@ -65,6 +65,20 @@ class MatchStrategy(str, Enum):
     UNION = "union"
 
 
+class ZoneMatchStrategy(str, Enum):
+    """How a detection intersecting several zones is resolved.
+
+    Zone matching is bounding-box *intersection*, not containment, so a box
+    can straddle zones with conflicting patterns.  See ZoneMinder/pyzmNg#68.
+    """
+    #: Keep as soon as any intersecting zone's pattern matches (pre-2.6 default).
+    ANY_MATCHING = "any_matching"
+    #: The first intersecting zone decides, keep or reject (pyzm 0.3.x / ES 6).
+    FIRST_INTERSECTING = "first_intersecting"
+    #: The zone covering most of the box decides.  Order-independent.
+    LARGEST_OVERLAP = "largest_overlap"
+
+
 class FrameStrategy(str, Enum):
     """How to pick the *best* frame across all analysed frames."""
     FIRST = "first"
@@ -186,7 +200,7 @@ class TypeOverrides(BaseModel):
 
 
 # Keys that may appear in section_general but only have global meaning.
-_GLOBAL_ONLY_KEYS = frozenset({"frame_strategy", "image_path"})
+_GLOBAL_ONLY_KEYS = frozenset({"frame_strategy", "image_path", "zone_match_strategy"})
 
 
 class DetectorConfig(BaseModel):
@@ -198,6 +212,7 @@ class DetectorConfig(BaseModel):
     # Global overrides (applied to all models unless overridden per-model)
     max_detection_size: str | None = None
     pattern: str = ".*"
+    zone_match_strategy: ZoneMatchStrategy = ZoneMatchStrategy.ANY_MATCHING
 
     # Past-detection matching
     match_past_detections: bool = False
@@ -274,6 +289,9 @@ class DetectorConfig(BaseModel):
             frame_strategy=frame_strat,
             max_detection_size=general.get("max_detection_size"),
             pattern=general.get("pattern", ".*"),
+            zone_match_strategy=ZoneMatchStrategy(
+                general.get("zone_match_strategy", ZoneMatchStrategy.ANY_MATCHING.value)
+            ),
             match_past_detections=_bool(general.get("match_past_detections")),
             past_det_max_diff_area=general.get("past_det_max_diff_area", "5%"),
             past_det_max_diff_area_labels=label_area_overrides,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,11 @@ Ensures that Python bools (True/False) and string values ('yes'/'no')
 are both handled correctly by config parsing.
 """
 
+import logging
+
 import pytest
 
-from pyzm.models.config import DetectorConfig, _bool
+from pyzm.models.config import DetectorConfig, ZoneMatchStrategy, _bool
 
 
 # ---------------------------------------------------------------------------
@@ -315,3 +317,44 @@ class TestMonitorIdAndImagePath:
     def test_image_path_default(self):
         cfg = DetectorConfig.from_dict(_minimal_ml_options())
         assert cfg.image_path == "/var/lib/zmeventnotification/images"
+
+
+# ---------------------------------------------------------------------------
+# zone_match_strategy  (Ref: ZoneMinder/pyzmNg#68)
+# ---------------------------------------------------------------------------
+
+class TestZoneMatchStrategy:
+    def test_default_is_any_matching(self):
+        cfg = DetectorConfig.from_dict(_minimal_ml_options())
+        assert cfg.zone_match_strategy is ZoneMatchStrategy.ANY_MATCHING
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("any_matching", ZoneMatchStrategy.ANY_MATCHING),
+            ("first_intersecting", ZoneMatchStrategy.FIRST_INTERSECTING),
+            ("largest_overlap", ZoneMatchStrategy.LARGEST_OVERLAP),
+        ],
+    )
+    def test_parsed_from_general(self, value, expected):
+        cfg = DetectorConfig.from_dict(
+            _minimal_ml_options(global_general_extras={"zone_match_strategy": value})
+        )
+        assert cfg.zone_match_strategy is expected
+
+    def test_unknown_value_raises(self):
+        with pytest.raises(ValueError):
+            DetectorConfig.from_dict(
+                _minimal_ml_options(global_general_extras={"zone_match_strategy": "closest"})
+            )
+
+    def test_per_type_section_warns_global_only(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="pyzm"):
+            cfg = DetectorConfig.from_dict(
+                _minimal_ml_options(
+                    section_general_extras={"zone_match_strategy": "largest_overlap"}
+                )
+            )
+        assert "zone_match_strategy" in caplog.text
+        # Per-type value is ignored; the global default stands.
+        assert cfg.zone_match_strategy is ZoneMatchStrategy.ANY_MATCHING

--- a/tests/test_ml/test_detector.py
+++ b/tests/test_ml/test_detector.py
@@ -14,6 +14,7 @@ from pyzm.models.config import (
     ModelFramework,
     ModelType,
     Processor,
+    ZoneMatchStrategy,
 )
 from pyzm.models.detection import BBox, Detection, DetectionResult
 
@@ -1706,3 +1707,52 @@ class TestRemoteInference:
         assert res.labels == ["person"]                       # object survived
         assert any("Gateway cannot run" in r.message for r in caplog.records)  # clear warning
         assert not any(r.levelname == "ERROR" for r in caplog.records)         # not a traceback
+
+
+# ===================================================================
+# TestApplyFiltersZoneStrategy  (Ref: ZoneMinder/pyzmNg#68)
+# ===================================================================
+
+@pytest.mark.integration
+class TestApplyFiltersZoneStrategy:
+    """Detector._apply_filters honours config.zone_match_strategy.
+
+    The issue's sliver case: the car's box is 70.7% inside ``street``
+    (which rejects it) and clips 10.4% of patternless ``drivewayfar``.
+    """
+
+    @staticmethod
+    def _zones():
+        from pyzm.models.zm import Zone
+        return [
+            Zone(name="street",
+                 points=[(1489, 84), (1919, 86), (1919, 296), (1483, 107)],
+                 pattern="(NeverMatchThis)"),
+            Zone(name="drivewayfar",
+                 points=[(1446, 86), (1483, 92), (1912, 294), (1912, 345),
+                         (1424, 246), (1394, 244)]),
+        ]
+
+    def _filter(self, strategy):
+        from pyzm.ml.detector import Detector
+        det = Detector.__new__(Detector)
+        det._config = DetectorConfig(zone_match_strategy=strategy)
+        det._pipeline = None
+        dets = [Detection(label="car", confidence=0.9,
+                          bbox=BBox(1554, 59, 1718, 167), model_name="test")]
+        return det._apply_filters(dets, zones=self._zones(), image_shape=(1080, 1920))
+
+    def test_default_any_matching_keeps(self):
+        filtered, errors = self._filter(ZoneMatchStrategy.ANY_MATCHING)
+        assert [d.label for d in filtered] == ["car"]
+        assert errors == []
+
+    def test_largest_overlap_drops(self):
+        filtered, errors = self._filter(ZoneMatchStrategy.LARGEST_OVERLAP)
+        assert filtered == []
+        assert len(errors) == 1
+
+    def test_first_intersecting_drops(self):
+        filtered, errors = self._filter(ZoneMatchStrategy.FIRST_INTERSECTING)
+        assert filtered == []
+        assert len(errors) == 1

--- a/tests/test_ml/test_filters.py
+++ b/tests/test_ml/test_filters.py
@@ -176,6 +176,249 @@ class TestFilterByZone:
         assert len(kept) == 1
 
 
+
+# ===================================================================
+# TestFilterByZoneStrategies  (Ref: ZoneMinder/pyzmNg#68)
+# ===================================================================
+
+# The real-world sliver case from the issue: a car in the street on a
+# 1920x1080 front-porch camera.  "street" holds 70.7% of the box and
+# rejects it by pattern; "drivewayfar" clips 10.4% of the box and is
+# patternless, so under "any_matching" it rescues a detection the
+# operator meant to exclude.
+_CAR_IN_STREET = (1554, 59, 1718, 167)
+_FRAME = (1080, 1920)
+
+
+def _street(pattern: str | None = "(NeverMatchThis)", ignore: str | None = None) -> dict:
+    return {
+        "name": "street",
+        "points": [(1489, 84), (1919, 86), (1919, 296), (1483, 107)],
+        "pattern": pattern,
+        "ignore_pattern": ignore,
+    }
+
+
+def _driveway_far(pattern: str | None = None, ignore: str | None = None) -> dict:
+    return {
+        "name": "drivewayfar",
+        "points": [(1446, 86), (1483, 92), (1912, 294), (1912, 345), (1424, 246), (1394, 244)],
+        "pattern": pattern,
+        "ignore_pattern": ignore,
+    }
+
+
+def _porch() -> dict:
+    """Large zone that does NOT intersect the car box."""
+    return {
+        "name": "porch",
+        "points": [(0, 0), (546, 2), (595, 256), (1426, 244), (1919, 347), (1919, 1079), (0, 1079)],
+        "pattern": None,
+    }
+
+
+@pytest.mark.integration
+class TestFilterByZoneStrategies:
+    """Zone-resolution strategies. Requires shapely."""
+
+    # -- any_matching (default, pre-2.6 behaviour) --
+
+    def test_default_strategy_lets_a_sliver_zone_rescue(self):
+        """Default is any_matching: drivewayfar rescues what street rejected."""
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+
+        kept, error_boxes = filter_by_zone(dets, [_street(), _driveway_far()], _FRAME)
+        assert [d.label for d in kept] == ["car"]
+        assert error_boxes == []
+
+    def test_any_matching_explicit_matches_default(self):
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+
+        kept, error_boxes = filter_by_zone(
+            dets, [_street(), _driveway_far()], _FRAME, strategy="any_matching",
+        )
+        assert [d.label for d in kept] == ["car"]
+        assert error_boxes == []
+
+    # -- first_intersecting (pyzm 0.3.x / ES 6 parity) --
+
+    def test_first_intersecting_rejection_is_terminal(self):
+        """street decides and rejects; drivewayfar never gets a say."""
+        from pyzm.ml.filters import filter_by_zone
+
+        det = _det("car", *_CAR_IN_STREET)
+
+        kept, error_boxes = filter_by_zone(
+            [det], [_street(), _driveway_far()], _FRAME, strategy="first_intersecting",
+        )
+        assert kept == []
+        assert error_boxes == [det.bbox]
+
+    def test_first_intersecting_skips_non_intersecting_zones(self):
+        """A zone the box misses does not get to decide."""
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+
+        kept, _ = filter_by_zone(
+            dets, [_porch(), _street(), _driveway_far()], _FRAME,
+            strategy="first_intersecting",
+        )
+        assert kept == []
+
+    def test_first_intersecting_is_order_dependent(self):
+        """Reversing zone order flips the outcome -- the documented drawback."""
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+
+        kept, error_boxes = filter_by_zone(
+            dets, [_driveway_far(), _street()], _FRAME, strategy="first_intersecting",
+        )
+        assert [d.label for d in kept] == ["car"]
+        assert error_boxes == []
+
+    def test_first_intersecting_ignore_pattern_is_terminal(self):
+        """ignore_pattern in the deciding zone suppresses outright."""
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+        zones = [_street(pattern=None, ignore="(car|truck)"), _driveway_far()]
+
+        kept, error_boxes = filter_by_zone(dets, zones, _FRAME, strategy="first_intersecting")
+        assert kept == []
+        assert len(error_boxes) == 1
+
+    def test_first_intersecting_keeps_when_deciding_zone_matches(self):
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+        zones = [_street(pattern="(car|person)"), _driveway_far(pattern="(NeverMatchThis)")]
+
+        kept, error_boxes = filter_by_zone(dets, zones, _FRAME, strategy="first_intersecting")
+        assert [d.label for d in kept] == ["car"]
+        assert error_boxes == []
+
+    # -- largest_overlap --
+
+    def test_largest_overlap_rejects_when_dominant_zone_rejects(self):
+        """street covers 70.7% of the box, drivewayfar 10.4% -- street decides."""
+        from pyzm.ml.filters import filter_by_zone
+
+        det = _det("car", *_CAR_IN_STREET)
+
+        kept, error_boxes = filter_by_zone(
+            [det], [_street(), _driveway_far()], _FRAME, strategy="largest_overlap",
+        )
+        assert kept == []
+        assert error_boxes == [det.bbox]
+
+    def test_largest_overlap_is_order_independent(self):
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+
+        kept, _ = filter_by_zone(
+            dets, [_driveway_far(), _street()], _FRAME, strategy="largest_overlap",
+        )
+        assert kept == []
+
+    def test_largest_overlap_keeps_when_dominant_zone_matches(self):
+        """Swap the patterns: the dominant zone now accepts the car."""
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+        zones = [_street(pattern=None), _driveway_far(pattern="(NeverMatchThis)")]
+
+        kept, error_boxes = filter_by_zone(dets, zones, _FRAME, strategy="largest_overlap")
+        assert [d.label for d in kept] == ["car"]
+        assert error_boxes == []
+
+    def test_largest_overlap_ignores_non_intersecting_zones(self):
+        """A big zone the box misses cannot win -- drivewayfar decides."""
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+        zones = [_porch(), _driveway_far(pattern="(car|person)")]
+
+        kept, _ = filter_by_zone(dets, zones, _FRAME, strategy="largest_overlap")
+        assert [d.label for d in kept] == ["car"]
+
+    def test_largest_overlap_ignore_pattern_is_terminal(self):
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+        zones = [_street(pattern=None, ignore="(car|truck)"), _driveway_far()]
+
+        kept, error_boxes = filter_by_zone(dets, zones, _FRAME, strategy="largest_overlap")
+        assert kept == []
+        assert len(error_boxes) == 1
+
+    def test_largest_overlap_tie_goes_to_first_zone(self):
+        """Two identical polygons: the earlier one decides."""
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("dog", 10, 10, 40, 40)]
+        square = [(0, 0), (50, 0), (50, 50), (0, 50)]
+        zones = [
+            {"name": "first", "points": square, "pattern": "person"},
+            {"name": "second", "points": square, "pattern": "dog"},
+        ]
+
+        kept, _ = filter_by_zone(dets, zones, (100, 100), strategy="largest_overlap")
+        assert kept == []
+
+    # -- shared behaviour --
+
+    @pytest.mark.parametrize(
+        "strategy", ["any_matching", "first_intersecting", "largest_overlap"],
+    )
+    def test_detection_outside_every_zone_is_dropped(self, strategy):
+        from pyzm.ml.filters import filter_by_zone
+
+        det = _det("car", 10, 10, 40, 40)
+
+        kept, error_boxes = filter_by_zone([det], [_street()], _FRAME, strategy=strategy)
+        assert kept == []
+        assert error_boxes == [det.bbox]
+
+    @pytest.mark.parametrize(
+        "strategy", ["any_matching", "first_intersecting", "largest_overlap"],
+    )
+    def test_empty_zone_list_passes_everything(self, strategy):
+        from pyzm.ml.filters import filter_by_zone
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+
+        kept, error_boxes = filter_by_zone(dets, [], _FRAME, strategy=strategy)
+        assert kept == dets
+        assert error_boxes == []
+
+    def test_strategy_accepts_enum(self):
+        from pyzm.ml.filters import filter_by_zone
+        from pyzm.models.config import ZoneMatchStrategy
+
+        dets = [_det("car", *_CAR_IN_STREET)]
+
+        kept, _ = filter_by_zone(
+            dets, [_street(), _driveway_far()], _FRAME,
+            strategy=ZoneMatchStrategy.LARGEST_OVERLAP,
+        )
+        assert kept == []
+
+    def test_unknown_strategy_raises(self):
+        from pyzm.ml.filters import filter_by_zone
+
+        with pytest.raises(ValueError):
+            filter_by_zone(
+                [_det("car", *_CAR_IN_STREET)], [_street()], _FRAME,
+                strategy="closest_zone",
+            )
+
 # ===================================================================
 # TestFilterBySize
 # ===================================================================

--- a/tests/test_ml/test_pipeline.py
+++ b/tests/test_ml/test_pipeline.py
@@ -13,6 +13,7 @@ from pyzm.models.config import (
     ModelFramework,
     ModelType,
     TypeOverrides,
+    ZoneMatchStrategy,
 )
 from pyzm.models.detection import BBox, Detection, DetectionResult
 
@@ -64,7 +65,7 @@ class TestModelPipeline:
         mock_create.return_value = mock_backend
 
         # Zone filter passes everything through
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(models=[mc], match_strategy=MatchStrategy.FIRST)
 
@@ -91,7 +92,7 @@ class TestModelPipeline:
         backend2 = _make_mock_backend("model2", [_det("car", model="model2"), _det("truck", model="model2")])
 
         mock_create.side_effect = [backend1, backend2]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc1, mc2],
@@ -123,7 +124,7 @@ class TestModelPipeline:
         backend2 = _make_mock_backend("model2", [_det("car", model="model2"), _det("truck", model="model2")])
 
         mock_create.side_effect = [backend1, backend2]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc1, mc2],
@@ -152,7 +153,7 @@ class TestModelPipeline:
         backend2 = _make_mock_backend("model2", [_det("car", model="model2")])
 
         mock_create.side_effect = [backend1, backend2]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc1, mc2],
@@ -184,7 +185,7 @@ class TestModelPipeline:
         backend_face = _make_mock_backend("dlib", [_det("John", model="dlib")])
 
         mock_create.side_effect = [backend_obj, backend_face]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc_obj, mc_face],
@@ -216,7 +217,7 @@ class TestModelPipeline:
         backend_face = _make_mock_backend("dlib", [_det("John", model="dlib")])
 
         mock_create.side_effect = [backend_obj, backend_face]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc_obj, mc_face],
@@ -269,7 +270,7 @@ class TestModelPipeline:
         good_backend = _make_mock_backend("good_model", [_det("person")])
 
         mock_create.side_effect = [bad_backend, good_backend]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc1, mc2],
@@ -300,7 +301,7 @@ class TestModelPipeline:
         backend2 = _make_mock_backend("model2", [_det("person"), _det("car")])
 
         mock_create.side_effect = [backend1, backend2]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc1, mc2],
@@ -356,7 +357,7 @@ class TestZoneRescaling:
         mc = _make_model_config("test")
         backend = _make_mock_backend("test", [_det("person")])
         mock_create.return_value = backend
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(models=[mc])
         pipeline = ModelPipeline(config)
@@ -392,7 +393,7 @@ class TestZoneRescaling:
         mc = _make_model_config("test")
         backend = _make_mock_backend("test", [_det("person")])
         mock_create.return_value = backend
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(models=[mc])
         pipeline = ModelPipeline(config)
@@ -417,7 +418,7 @@ class TestZoneRescaling:
         mc = _make_model_config("test")
         backend = _make_mock_backend("test", [_det("person")])
         mock_create.return_value = backend
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(models=[mc])
         pipeline = ModelPipeline(config)
@@ -457,7 +458,7 @@ class TestPerTypeConfig:
         backend_face2 = _make_mock_backend("face2", [_det("Bob", model="face2")])
 
         mock_create.side_effect = [backend_obj1, backend_obj2, backend_face1, backend_face2]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc_obj1, mc_obj2, mc_face1, mc_face2],
@@ -510,7 +511,7 @@ class TestPerTypeConfig:
         ])
 
         mock_create.side_effect = [backend_obj, backend_face]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         # Saved past detection: "person" at exact same bbox
         mock_load.return_value = ([[10, 10, 50, 50]], ["person"])
@@ -594,7 +595,7 @@ class TestAudioContext:
         mock_backend = _make_mock_backend("BirdNET", [])
         mock_backend.detect_audio = MagicMock(return_value=audio_dets)
         mock_create.return_value = mock_backend
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(models=[mc], match_strategy=MatchStrategy.FIRST)
         pipeline = ModelPipeline(config)
@@ -628,7 +629,7 @@ class TestAudioContext:
         mock_backend = _make_mock_backend("BirdNET", [])
         mock_backend.detect_audio = MagicMock()
         mock_create.return_value = mock_backend
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(models=[mc], match_strategy=MatchStrategy.FIRST)
         pipeline = ModelPipeline(config)
@@ -667,7 +668,7 @@ class TestAudioContext:
         backend_audio.detect_audio = MagicMock(return_value=audio_dets)
 
         mock_create.side_effect = [backend_obj, backend_audio]
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(
             models=[mc_obj, mc_audio],
@@ -700,7 +701,7 @@ class TestAudioContext:
         mock_backend = _make_mock_backend("BirdNET", [])
         mock_backend.detect_audio = MagicMock(side_effect=RuntimeError("BirdNET crashed"))
         mock_create.return_value = mock_backend
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(models=[mc], match_strategy=MatchStrategy.FIRST)
         pipeline = ModelPipeline(config)
@@ -712,3 +713,64 @@ class TestAudioContext:
         # Should NOT raise
         result = pipeline.run(mock_image)
         assert result.detections == []
+
+
+# ===================================================================
+# TestZoneMatchStrategyWiring  (Ref: ZoneMinder/pyzmNg#68)
+# ===================================================================
+
+@pytest.mark.integration
+class TestZoneMatchStrategyWiring:
+    """The configured zone_match_strategy reaches the real zone filter.
+
+    Real filter_by_zone here (needs shapely) -- only the backend is mocked.
+    Scenario is the issue's sliver case: a car whose box sits mostly in a
+    zone that rejects it and clips a patternless zone that would rescue it.
+    """
+
+    @staticmethod
+    def _zones():
+        from pyzm.models.zm import Zone
+        return [
+            Zone(name="street",
+                 points=[(1489, 84), (1919, 86), (1919, 296), (1483, 107)],
+                 pattern="(NeverMatchThis)"),
+            Zone(name="drivewayfar",
+                 points=[(1446, 86), (1483, 92), (1912, 294), (1912, 345),
+                         (1424, 246), (1394, 244)]),
+        ]
+
+    def _run(self, mock_create, strategy):
+        from pyzm.ml.pipeline import ModelPipeline
+
+        mc = _make_model_config("yolo")
+        mock_create.return_value = _make_mock_backend(
+            "yolo", [_det("car", 1554, 59, 1718, 167)],
+        )
+        config = DetectorConfig(
+            models=[mc], match_strategy=MatchStrategy.FIRST,
+            zone_match_strategy=strategy,
+        )
+        pipeline = ModelPipeline(config)
+
+        mock_image = MagicMock()
+        mock_image.shape = (1080, 1920, 3)
+        return pipeline.run(mock_image, zones=self._zones())
+
+    @patch("pyzm.ml.pipeline._create_backend")
+    def test_default_any_matching_keeps(self, mock_create):
+        result = self._run(mock_create, ZoneMatchStrategy.ANY_MATCHING)
+        assert [d.label for d in result.detections] == ["car"]
+        assert result.error_boxes == []
+
+    @patch("pyzm.ml.pipeline._create_backend")
+    def test_largest_overlap_drops(self, mock_create):
+        result = self._run(mock_create, ZoneMatchStrategy.LARGEST_OVERLAP)
+        assert result.detections == []
+        assert len(result.error_boxes) == 1
+
+    @patch("pyzm.ml.pipeline._create_backend")
+    def test_first_intersecting_drops(self, mock_create):
+        result = self._run(mock_create, ZoneMatchStrategy.FIRST_INTERSECTING)
+        assert result.detections == []
+        assert len(result.error_boxes) == 1

--- a/tests/test_ml/test_pipeline_lazy.py
+++ b/tests/test_ml/test_pipeline_lazy.py
@@ -122,7 +122,7 @@ class TestPrepare:
         backend.name = "test"
         backend.detect.return_value = [_det("person")]
         mock_create.return_value = backend
-        mock_zone_filter.side_effect = lambda dets, zones, shape: (dets, [])
+        mock_zone_filter.side_effect = lambda dets, zones, shape, strategy=None: (dets, [])
 
         config = DetectorConfig(models=[_make_mc()], match_strategy=MatchStrategy.FIRST)
 


### PR DESCRIPTION
Fixes the zone-resolution problem described in #68.

## The problem

Zone matching is bounding-box *intersection*, not containment, so one detection can land in several zones at once. Until now a detection rejected by one zone's `pattern` fell through and could be kept by any later zone it also intersected. An exclusion zone bordering a permissive one was therefore defeated by any object whose box clipped a few pixels across the shared edge, and an ES 6 config — written against pyzm 0.3.x, where the **first** intersecting zone decided — silently widened on migration with no way back.

## The change

New `ZoneMatchStrategy` enum and a `zone_match_strategy` setting on `DetectorConfig`, read from the top-level `ml_sequence.general` section:

| value | behaviour |
|---|---|
| `any_matching` | Keep as soon as any intersecting zone's `pattern` matches. Unchanged, and still the default. |
| `first_intersecting` | The first intersecting zone decides, keep or reject. pyzm 0.3.x / ES 6 parity. Order-dependent. |
| `largest_overlap` | The zone covering the largest share of the box decides; ties go to the earlier zone. Order-independent. |

Under the two new strategies a rejection is final — by `ignore_pattern` or by a `pattern` mismatch — so an exclusion zone cannot be overridden by a zone the box merely clips. That is what makes "never alert on this label here" expressible, which #68 notes is currently impossible even with `ignore_pattern`.

`zone_match_strategy` is a global-only key: zone filtering runs once, after all model types have been sequenced, so a per-type section logs the usual "no per-type effect" warning.

**The default is unchanged.** Upgrading pyzm does not alter which detections survive; the new strategies are opt-in.

- `pyzm/models/config.py` — enum, config field, `from_dict` parsing, `_GLOBAL_ONLY_KEYS`
- `pyzm/ml/filters.py` — `filter_by_zone()` gains a `strategy` argument (defaulted, so existing callers are unaffected); one helper per strategy plus a shared `_zone_verdict()` for the two where a single zone decides
- `pyzm/ml/pipeline.py`, `pyzm/ml/detector.py` — both call sites pass `config.zone_match_strategy`
- `docs/guide/detection.rst` — new "Resolving overlapping zones" section, cross-referenced from the `ignore_pattern` docs; also drops a stale docstring claim that an empty zone list synthesises a full-image zone (it doesn't — filtering is skipped)

## Tests

Written first, watched fail. 20 new cases in `tests/test_ml/test_filters.py` built on the exact sliver scenario from the issue — verified with shapely that `street` holds 70.7% of the car's box and `drivewayfar` 10.4%, matching the numbers reported there. They cover the order-dependence of `first_intersecting`, the order-independence and tie-breaking of `largest_overlap`, terminal `ignore_pattern`, and rejection of an unknown strategy value.

Plus config-parsing tests and wiring tests that exercise the *real* filter through both `ModelPipeline.run()` and `Detector._apply_filters()`. The wiring tests were mutation-checked: removing the `strategy=` kwarg from either call site turns them red.

Tier-1 gate: 1120 passed, 81 skipped. 6 pre-existing failures remain (5 PyJWT/starlette deprecation warnings promoted to errors by `filterwarnings=error`, 1 alpr subprocess test) — they fail identically on `master` in the same environment and are unrelated to this change. Tier-2 (`make release-gate`) not run; it needs models and a live ZoneMinder.

refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYSaA3uVUvRUku9LApa3pq